### PR TITLE
Fix wrong key.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -61,9 +61,9 @@ public class Robot extends TimedRobot {
     }
     // get the RobotId string from the RoboRIO's Preferences
     String strId = Preferences.getString(Constants.kRobotIdKey, RobotId.Default.name());
-    // match that string to an RobotId by looking at all possible RobotId enums
+    // match that string to a RobotId by looking at all possible RobotId enums
     for (RobotId rid : RobotId.values()) {
-      // does the preference string match the preference string?
+      // does the preference string match the RobotId enum?
       if (strId.equals(rid.name())) {
         // yes, this instance is the desired RobotId
         kRobotId = rid;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -23,10 +23,22 @@ public class Robot extends TimedRobot {
   private Command m_autoCommand;
   private RobotContainer m_robotContainer;
 
+  /**
+   * Set of known Robot Names.
+   * <p>The name of a robot in the RoboRIO's persistent memory.
+   * At deploy time, that name is used to set the corresponding RobotId.
+   * <p>Note that the RobotId is determined at Deploy time.
+   */
   public enum RobotId {
-    Default, SwerveCompetition, SwerveTest,
+    Default,
+    SwerveCompetition, SwerveTest,
     ClassBot1, ClassBot2, ClassBot3, ClassBot4
   };
+  /**
+   * The Robot Identity.
+   * <p><b>Note: kRobotId is not a constant.</b></p>
+   */
+  // assume a default robot identity
   public static RobotId kRobotId = RobotId.Default;
 
   /**
@@ -35,27 +47,28 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
-    // Determine the Robot Identity from Preferences
+    // Determine the Robot Identity from the RoboRIO's onboard Preferences
     // To Set the Robot Name
     //   SimGUI: Persistent Values, Preferences, RobotId, then restart Simulation
     //     changes networktables.json, networktables.json.bck (both Untracked)
-    // set the default preference to something safe
-    if (!Preferences.containsKey(kRobotId.name())) {
-      Preferences.setString(kRobotId.name(), RobotId.Default.toString());
+    //   Uncomment the next line, set the desired RobotId, deploy, and then comment the line out
+    //     Preferences.setString(Constants.kRobotIdKey, RobotId.SwerveTest.name());
+    //
+    // check whether Preferences has an entry for the RobotId
+    if (!Preferences.containsKey(Constants.kRobotIdKey)) {
+      // There is no such key. Set it to the default identity.
+      Preferences.setString(Constants.kRobotIdKey, RobotId.Default.name());
     }
-    // get the RobotId from Preferences
-    String strId = Preferences.getString(Constants.kRobotIdKey, RobotId.Default.toString());
-    // match the string to an RobotId
+    // get the RobotId string from the RoboRIO's Preferences
+    String strId = Preferences.getString(Constants.kRobotIdKey, RobotId.Default.name());
+    // match that string to an RobotId by looking at all possible RobotId enums
     for (RobotId rid : RobotId.values()) {
-      // does it match the preference string?
+      // does the preference string match the preference string?
       if (strId.equals(rid.name())) {
-        // yes, so it is the RobotId
+        // yes, this instance is the desired RobotId
         kRobotId = rid;
       }
     }
-
-    // TODO: Remove this line when someone is able to test whether or not preferences are working
-    kRobotId = RobotId.SwerveTest;
     // report the RobotId to the SmartDashboard
     SmartDashboard.putString("RobotID", kRobotId.name());
 

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -14,6 +14,6 @@ public final class Constants {
   public static final String kCanivoreCAN = "CANivore";
   public static final String kRioCAN = "rio";
 
-  // RobotId key in rio preferences
+  /** The key used to access the RobotId name in the RoboRIO's persistent memory. */
   public static final String kRobotIdKey = "RobotId";
 }


### PR DESCRIPTION
<!--
PLEASE CHECK THE PR GUIDLINES:
 https://docs.google.com/document/d/14ZIhQRlUPK0wl5_AmM80N2D2KJUd6k_7I6isLS89YKU/edit
These are the things we are going to be checking your PR has, if it doesn't your PR will be rejected!
-->

## Overview
<!-- A general very short overview of the PR -->
This PR fixes bug in RobotId processing where "Default" instead of Constants.kRobotIdKey was used as the Preferences key.


## Design Doc
<!-- Link your approved design doc. We will be checking that the code fits everything in the design doc. If the PR is only meant to address part of the deisgn doc, note here what is not yet implemented from the Design Doc -->
None.

## Tests Ran
<!-- Explicity list the exact tests you ran. These should be the tests listed in the Testing and Evaluation section of your design doc, and of every merged design doc. List the actual result of the test and how it was within the measurement specified by the test. -->
Builds. SimGUI. Bug discoved and fixed in angled-elevator.

## Additional Notes
<!-- Anything else that will help the reviewer understand your PR -->
The SwerveCompetition robot has the proper key. The SwerveTest robot probably does not.