### PR TITLE
Jitter fix and yaw/odometry misalignment fix

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -115,7 +115,6 @@ public class Drivetrain extends SubsystemBase {
     
     m_pigeon = new WPI_Pigeon2(DriveConstants.kPigeon, DriveConstants.kPigeonCAN);
     m_pigeon.configFactoryDefault();
-    setPigeonYaw(DriveConstants.kStartingHeadingDegrees);
 
     // m_modules = new ModuleOld[] {
     //   ModuleOld.create(ModuleConstants.FRONT_LEFT, m_swerveModulesTab),
@@ -143,11 +142,13 @@ public class Drivetrain extends SubsystemBase {
 
     m_poseEstimator = new SwerveDrivePoseEstimator(
       DriveConstants.kKinematics,
-      m_pigeon.getRotation2d(),
+      getYaw(),
       getModulePositions(),
       new Pose2d() // initial Odometry Location
     );
     m_poseEstimator.setVisionMeasurementStdDevs(VisionConstants.kBaseVisionPoseStdDevs);
+
+    setPigeonYaw(DriveConstants.kStartingHeadingDegrees);
 
     m_xController = new PIDController(DriveConstants.kTranslationalP, 0, DriveConstants.kTranslationalD);
     m_yController = new PIDController(DriveConstants.kTranslationalP, 0, DriveConstants.kTranslationalD);
@@ -347,6 +348,10 @@ public class Drivetrain extends SubsystemBase {
    */
   public void setPigeonYaw(double degrees) {
     m_pigeon.setYaw(degrees);
+    // the odometry stores an offset from the current pigeon angle
+    // changing the angle makes that offset inaccurate, so must reset the pose as well.
+    // keep the same translation, but set the odometry angle to what we want the angle to be.
+    resetOdometry(new Pose2d(getPose().getTranslation(), Rotation2d.fromDegrees(degrees)));
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -229,7 +229,7 @@ public class Drivetrain extends SubsystemBase {
   * @return the pigeon's heading in a Rotation2d
   */
   public Rotation2d getYaw() {
-    return (DriveConstants.kInvertGyro) ? Rotation2d.fromDegrees(MathUtil.inputModulus(360 - m_pigeon.getYaw(), -180, 180))
+    return (DriveConstants.kInvertGyro) ? Rotation2d.fromDegrees(MathUtil.inputModulus(180 - m_pigeon.getYaw(), -180, 180))
         : Rotation2d.fromDegrees(MathUtil.inputModulus(m_pigeon.getYaw(), -180, 180));
   }
 

--- a/src/main/java/frc/robot/subsystems/Module.java
+++ b/src/main/java/frc/robot/subsystems/Module.java
@@ -91,11 +91,13 @@ public class Module {
 
   private void setAngle(SwerveModuleState desiredState) {
     // Prevent rotating module if desired speed < 1%. Prevents Jittering.
-    Rotation2d angle = (Math.abs(desiredState.speedMetersPerSecond) <= (DriveConstants.kMaxSpeed * 0.01)
-        && m_stateDeadband) ? m_lastAngle : desiredState.angle;
+    if (m_stateDeadband && (Math.abs(desiredState.speedMetersPerSecond) <= (DriveConstants.kMaxSpeed * 0.01))) {
+      stop();
+      return;
+    }
 
-    m_angleMotor.set(ControlMode.Position, Conversions.degreesToFalcon(angle.getDegrees(), DriveConstants.kAngleGearRatio));
-    m_lastAngle = angle;
+    m_angleMotor.set(ControlMode.Position, Conversions.degreesToFalcon(desiredState.angle.getDegrees(), DriveConstants.kAngleGearRatio));
+    m_lastAngle = desiredState.angle;
   }
 
   public void enableStateDeadband(boolean enabled) {

--- a/src/main/java/frc/robot/subsystems/Module.java
+++ b/src/main/java/frc/robot/subsystems/Module.java
@@ -25,7 +25,6 @@ public class Module {
 
   private final int m_moduleIndex;
   private Rotation2d m_angleOffset;
-  private Rotation2d m_lastAngle;
 
   private final String m_moduleAbbr;
 
@@ -60,8 +59,7 @@ public class Module {
     m_driveMotor = new WPI_TalonFX(moduleConstants.getDrivePort(), DriveConstants.kDriveMotorCAN);
     configDriveMotor();
 
-    m_lastAngle = getState().angle;
-    setDesiredState(new SwerveModuleState(0, m_lastAngle), false);
+    setDesiredState(new SwerveModuleState(0, getAngle()), false);
 
     setupShuffleboard();
   }

--- a/src/main/java/frc/robot/subsystems/Module.java
+++ b/src/main/java/frc/robot/subsystems/Module.java
@@ -95,7 +95,6 @@ public class Module {
     }
 
     m_angleMotor.set(ControlMode.Position, Conversions.degreesToFalcon(desiredState.angle.getDegrees(), DriveConstants.kAngleGearRatio));
-    m_lastAngle = desiredState.angle;
   }
 
   public void enableStateDeadband(boolean enabled) {


### PR DESCRIPTION
A quick fix, tested on the robot. Fixes real yaw and odometer yaw being different, and "jitter" on state deadband reverted to pre-richie version, which did not make the motors move on redeploy or on staying still.